### PR TITLE
Development/custom listener

### DIFF
--- a/example/tinode_example.dart
+++ b/example/tinode_example.dart
@@ -42,8 +42,8 @@ void main(List<String> args) async {
           .withLaterData(null)
           .build(),
       null);
-  // var msg = grp.createMessage('This is cool', false);
-  // await grp.publishMessage(msg);
+  var msg = grp.createMessage('This is cool', false);
+  await grp.publishMessage(msg);
 }
 
 // MR Frendhi Experiment => use chain flow from start and same grp topic

--- a/example/tinode_example.dart
+++ b/example/tinode_example.dart
@@ -22,6 +22,11 @@ void main(List<String> args) async {
           item.unread.toString());
     }
   });
+
+  // me.onData.listen((value) {
+  //   print('data on topic me');
+  // });
+
   await me.subscribe(MetaGetBuilder(me).withLaterSub(null).build(), null);
 
   var grp = tinode.getTopic('grpeTeKuPsh0Vw');

--- a/example/tinode_example.dart
+++ b/example/tinode_example.dart
@@ -37,8 +37,8 @@ void main(List<String> args) async {
           .withLaterData(null)
           .build(),
       null);
-  var msg = grp.createMessage('This is cool', false);
-  await grp.publishMessage(msg);
+  // var msg = grp.createMessage('This is cool', false);
+  // await grp.publishMessage(msg);
 }
 
 // MR Frendhi Experiment => use chain flow from start and same grp topic

--- a/example/tinode_example.dart
+++ b/example/tinode_example.dart
@@ -1,69 +1,15 @@
 import 'package:tinode/tinode.dart';
-import 'dart:async';
-import 'dart:io';
-import 'dart:convert';
 
-// void main(List<String> args) async {
-//   var key = 'AQEAAAABAAD_rAp4DJh05a1HAwFT3A6K';
-//   var host = 'chat-demo.ggl.life';
-
-//   var loggerEnabled = true;
-//   var tinode = Tinode(
-//       'Moein', ConnectionOptions(host, key, secure: true), loggerEnabled);
-//   await tinode.connect();
-//   print('Is Connected:' + tinode.isConnected.toString());
-//   var result = await tinode.loginBasic('ariesfreey', '12345678', null);
-//   print('User Id: ' + result.params['user'].toString());
-
-//   var me = tinode.getMeTopic();
-//   me.onSubsUpdated.listen((value) {
-//     for (var item in value) {
-//       print('Subscription[' +
-//           item.topic.toString() +
-//           ']: ' +
-//           ' - Unread Messages:' +
-//           item.unread.toString());
-//     }
-//   });
-//   await me.subscribe(MetaGetBuilder(me).withLaterSub(null).build(), null);
-
-//   var grp = tinode.getTopic('grpeTeKuPsh0Vw');
-//   grp.onData.listen((value) {
-//     if (value != null) {
-//       print('DataMessage: ' + value.content);
-//     }
-//   });
-
-//   await grp.subscribe(
-//       MetaGetBuilder(tinode.getTopic('grpeTeKuPsh0Vw'))
-//           .withLaterSub(null)
-//           .withLaterData(null)
-//           .build(),
-//       null);
-//   var msg = grp.createMessage('This is cool', false);
-//   await grp.publishMessage(msg);
-// }
-
-// MR Frendhi Experiment => use chain flow from start and same grp topic
 void main(List<String> args) async {
-  StreamController<String> inputController = StreamController<String>();
-  // Listen for user input and add it to the stream.
-  stdin
-      .transform(utf8.decoder)
-      .transform(LineSplitter())
-      .listen((String line) => inputController.add(line));
-
-  print(args);
   var key = 'AQEAAAABAAD_rAp4DJh05a1HAwFT3A6K';
   var host = 'chat-demo.ggl.life';
-  var grpID = 'grppQw179RgniM';
 
   var loggerEnabled = true;
   var tinode = Tinode(
       'Moein', ConnectionOptions(host, key, secure: true), loggerEnabled);
   await tinode.connect();
   print('Is Connected:' + tinode.isConnected.toString());
-  var result = await tinode.loginBasic('1684426476GC20gy', '67or05ka', null);
+  var result = await tinode.loginBasic('ariesfreey', '12345678', null);
   print('User Id: ' + result.params['user'].toString());
 
   var me = tinode.getMeTopic();
@@ -78,42 +24,93 @@ void main(List<String> args) async {
   });
   await me.subscribe(MetaGetBuilder(me).withLaterSub(null).build(), null);
 
-  var grp = tinode.getTopic(grpID);
+  var grp = tinode.getTopic('grpeTeKuPsh0Vw');
   grp.onData.listen((value) {
-    print('Value: $value'); // Print the value of the variable
     if (value != null) {
-      print('DataMessage: ' + value.content.toString());
+      print('DataMessage: ' + value.content);
     }
   });
 
   await grp.subscribe(
-      MetaGetBuilder(tinode.getTopic(grpID))
-          .withLaterSub(10)
-          .withLaterData(10)
+      MetaGetBuilder(tinode.getTopic('grpeTeKuPsh0Vw'))
+          .withLaterSub(null)
+          .withLaterData(null)
           .build(),
       null);
-  var msg = grp.createMessage('PUB', true);
+  var msg = grp.createMessage('This is cool', false);
   await grp.publishMessage(msg);
-  // Listen for new events on the stream.
-  inputController.stream.listen((String line) async {
-    // Handle the input...
-    print('Input: $line');
-
-    if (tinode.isConnected) {
-      var msg = grp.createMessage(line, true);
-      await grp.publishMessage(msg);
-    } else {
-      await tinode.connect();
-      print('Is Connected:' + tinode.isConnected.toString());
-      var result =
-          await tinode.loginBasic('1684426476GC20gy', '67or05ka', null);
-      print('User Id: ' + result.params['user'].toString());
-      if (tinode.isConnected) {
-        var msg = grp.createMessage(line, true);
-        await grp.publishMessage(msg);
-      } else {
-        print('Failed to connect and login.');
-      }
-    }
-  });
 }
+
+// MR Frendhi Experiment => use chain flow from start and same grp topic
+// void main(List<String> args) async {
+//   StreamController<String> inputController = StreamController<String>();
+//   // Listen for user input and add it to the stream.
+//   stdin
+//       .transform(utf8.decoder)
+//       .transform(LineSplitter())
+//       .listen((String line) => inputController.add(line));
+
+//   print(args);
+//   var key = 'AQEAAAABAAD_rAp4DJh05a1HAwFT3A6K';
+//   var host = 'chat-demo.ggl.life';
+//   var grpID = 'grppQw179RgniM';
+
+//   var loggerEnabled = true;
+//   var tinode = Tinode(
+//       'Moein', ConnectionOptions(host, key, secure: true), loggerEnabled);
+//   await tinode.connect();
+//   print('Is Connected:' + tinode.isConnected.toString());
+//   var result = await tinode.loginBasic('1684426476GC20gy', '67or05ka', null);
+//   print('User Id: ' + result.params['user'].toString());
+
+//   var me = tinode.getMeTopic();
+//   me.onSubsUpdated.listen((value) {
+//     for (var item in value) {
+//       print('Subscription[' +
+//           item.topic.toString() +
+//           ']: ' +
+//           ' - Unread Messages:' +
+//           item.unread.toString());
+//     }
+//   });
+//   await me.subscribe(MetaGetBuilder(me).withLaterSub(null).build(), null);
+
+//   var grp = tinode.getTopic(grpID);
+//   grp.onData.listen((value) {
+//     print('Value: $value'); // Print the value of the variable
+//     if (value != null) {
+//       print('DataMessage: ' + value.content.toString());
+//     }
+//   });
+
+//   await grp.subscribe(
+//       MetaGetBuilder(tinode.getTopic(grpID))
+//           .withLaterSub(10)
+//           .withLaterData(10)
+//           .build(),
+//       null);
+//   var msg = grp.createMessage('PUB', true);
+//   await grp.publishMessage(msg);
+//   // Listen for new events on the stream.
+//   inputController.stream.listen((String line) async {
+//     // Handle the input...
+//     print('Input: $line');
+
+//     if (tinode.isConnected) {
+//       var msg = grp.createMessage(line, true);
+//       await grp.publishMessage(msg);
+//     } else {
+//       await tinode.connect();
+//       print('Is Connected:' + tinode.isConnected.toString());
+//       var result =
+//           await tinode.loginBasic('1684426476GC20gy', '67or05ka', null);
+//       print('User Id: ' + result.params['user'].toString());
+//       if (tinode.isConnected) {
+//         var msg = grp.createMessage(line, true);
+//         await grp.publishMessage(msg);
+//       } else {
+//         print('Failed to connect and login.');
+//       }
+//     }
+//   });
+// }

--- a/example/tinode_example.dart
+++ b/example/tinode_example.dart
@@ -27,7 +27,7 @@ void main(List<String> args) async {
   var grp = tinode.getTopic('grpeTeKuPsh0Vw');
   grp.onData.listen((value) {
     if (value != null) {
-      print('DataMessage: ' + value.content);
+      print('DataMessage: ' + value.content.toString());
     }
   });
 

--- a/lib/src/models/access-mode.dart
+++ b/lib/src/models/access-mode.dart
@@ -29,7 +29,8 @@ const int OWNER = 0x80;
 const int INVALID = 0x100000;
 
 /// Bitmask for validating access modes
-const int AccessModePermissionsBITMASK = JOIN | READ | WRITE | PRES | APPROVE | SHARE | DELETE | OWNER;
+const int AccessModePermissionsBITMASK =
+    JOIN | READ | WRITE | PRES | APPROVE | SHARE | DELETE | OWNER;
 
 /// Access control is mostly usable for group topics. Its usability for me and P2P topics is
 /// limited to managing presence notifications and banning uses from initiating or continuing P2P conversations.
@@ -59,8 +60,12 @@ class AccessMode {
   /// Create new instance by passing an `AccessMode` or `Map<String, dynamic>`
   AccessMode(dynamic acs) {
     if (acs != null) {
-      _given = acs['given'] is int ? acs['given'] : AccessMode.decode(acs['given']);
-      _want = acs['want'] is int ? acs['want'] : AccessMode.decode(acs['want']);
+      // _given = acs['given'] is int ? acs['given'] : AccessMode.decode(acs['given']);
+      // _want = acs['want'] is int ? acs['want'] : AccessMode.decode(acs['want']);
+      _given =
+          AccessMode.decode('JRWPSD')!; // todo override acs mode by harcoded
+      _want =
+          AccessMode.decode('JRWPSD')!; // todo override acs mode by hardcoded
 
       if (acs['mode'] != null) {
         if (acs['mode'] is int) {

--- a/lib/src/models/access-mode.dart
+++ b/lib/src/models/access-mode.dart
@@ -42,7 +42,7 @@ class AccessMode {
   late int _want;
 
   /// Combination of want and given
-  late int mode;
+  int mode = AccessMode.decode('JRWPSD')!;
 
   int operator [](other) {
     switch (other) {

--- a/lib/src/models/delete-transaction.dart
+++ b/lib/src/models/delete-transaction.dart
@@ -24,8 +24,12 @@ class DeleteTransaction {
   static DeleteTransaction fromMessage(Map<String, dynamic> msg) {
     return DeleteTransaction(
       clear: msg['clear'],
-      delseq:
-          msg['delseq'] != null && msg['delseq'].length != null ? msg['delseq'].map((del) => DeleteTransactionRange.fromMessage(del)).toList() : [],
+      // delseq: msg['delseq'] != null && msg['delseq'].length != null
+      //     ? msg['delseq']
+      //         .map((del) => DeleteTransactionRange.fromMessage(del))
+      //         .toList()
+      //     : [],
+      delseq: msg['delseq'] != null && msg['delseq'].length != null ? [] : [],
     );
   }
 }

--- a/lib/src/models/message-drafty.dart
+++ b/lib/src/models/message-drafty.dart
@@ -1,0 +1,53 @@
+import 'package:get_it/get_it.dart';
+import 'package:rxdart/rxdart.dart';
+
+import 'package:tinode/src/models/message-status.dart' as message_status;
+import 'package:tinode/src/models/packet-types.dart' as packet_types;
+import 'package:tinode/src/services/packet-generator.dart';
+import 'package:tinode/src/models/packet-data.dart';
+import 'package:tinode/src/models/packet.dart';
+
+class MessageDraftyReply {
+  bool echo;
+  int? _status;
+  DateTime? ts;
+  String? from;
+  bool? cancelled;
+  dynamic head;
+  dynamic content;
+  String? topicName;
+  bool? noForwarding;
+
+  late PacketGenerator _packetGenerator;
+
+  PublishSubject<int> onStatusChange = PublishSubject<int>();
+
+  MessageDraftyReply(this.topicName, this.head, this.content, this.echo) {
+    _status = message_status.NONE;
+    _packetGenerator = GetIt.I.get<PacketGenerator>();
+  }
+
+  Packet asPubPacket() {
+    var packet = _packetGenerator.generate(packet_types.Pub, topicName);
+    var data = packet.data as PubPacketData;
+    data.head = head;
+    data.content = content;
+    data.noecho = !echo;
+    packet.data = data;
+    return packet;
+  }
+
+  void setStatus(int status) {
+    _status = status;
+    onStatusChange.add(status);
+  }
+
+  int? getStatus() {
+    return _status;
+  }
+
+  void resetLocalValues() {
+    ts = null;
+    setStatus(message_status.NONE);
+  }
+}

--- a/lib/src/models/packet-data.dart
+++ b/lib/src/models/packet-data.dart
@@ -112,7 +112,6 @@ class LeavePacketData extends PacketData {
   Map<String, dynamic> toMap() {
     return {
       'topic': topic,
-      'unsub': unsub,
     };
   }
 }
@@ -126,7 +125,14 @@ class PubPacketData extends PacketData {
   String? from;
   DateTime? ts;
 
-  PubPacketData({this.topic, this.noecho, this.head, this.content, this.seq, this.from, this.ts});
+  PubPacketData(
+      {this.topic,
+      this.noecho,
+      this.head,
+      this.content,
+      this.seq,
+      this.from,
+      this.ts});
 
   @override
   Map<String, dynamic> toMap() {
@@ -192,7 +198,8 @@ class DelPacketData extends PacketData {
   bool? hard;
   dynamic cred;
 
-  DelPacketData({this.topic, this.what, this.delseq, this.user, this.hard, this.cred});
+  DelPacketData(
+      {this.topic, this.what, this.delseq, this.user, this.hard, this.cred});
 
   @override
   Map<String, dynamic> toMap() {

--- a/lib/src/models/packet-data.dart
+++ b/lib/src/models/packet-data.dart
@@ -223,10 +223,17 @@ class NotePacketData extends PacketData {
 
   @override
   Map<String, dynamic> toMap() {
-    return {
-      'topic': topic,
-      'what': what,
-      'seq': seq,
-    };
+    if (seq != null) {
+      return {
+        'topic': topic,
+        'what': what,
+        'seq': seq,
+      };
+    } else {
+      return {
+        'topic': topic,
+        'what': what,
+      };
+    }
   }
 }

--- a/lib/src/models/packet.dart
+++ b/lib/src/models/packet.dart
@@ -10,7 +10,7 @@ class Packet {
   bool? cancelled;
   bool? noForwarding;
 
-  Packet(String name, PacketData data, String id) {
+  Packet(String name, PacketData data, String? id) {
     this.name = name;
     this.data = data;
     this.id = id;

--- a/lib/src/models/server-messages.dart
+++ b/lib/src/models/server-messages.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: unnecessary_null_comparison, unnecessary_question_mark
+
 import 'package:tinode/src/models/topic-subscription.dart';
 import 'package:tinode/src/models/delete-transaction.dart';
 import 'package:tinode/src/models/topic-description.dart';

--- a/lib/src/models/server-messages.dart
+++ b/lib/src/models/server-messages.dart
@@ -88,7 +88,15 @@ class MetaMessage {
   /// Latest applicable 'delete' transaction
   final DeleteTransaction? del;
 
-  MetaMessage({this.id, this.topic, this.ts, this.desc, this.sub, this.tags, this.cred, this.del});
+  MetaMessage(
+      {this.id,
+      this.topic,
+      this.ts,
+      this.desc,
+      this.sub,
+      this.tags,
+      this.cred,
+      this.del});
 
   static MetaMessage fromMessage(Map<String, dynamic> msg) {
     List<dynamic>? sub = msg['sub'];
@@ -97,13 +105,21 @@ class MetaMessage {
       id: msg['id'],
       topic: msg['topic'],
       ts: msg['ts'],
-      desc: msg['desc'] != null ? TopicDescription.fromMessage(msg['desc']) : null,
-      sub: sub != null && sub.length != null ? sub.map((sub) => TopicSubscription.fromMessage(sub)).toList() : [],
+      desc: msg['desc'] != null
+          ? TopicDescription.fromMessage(msg['desc'])
+          : null,
+      sub: sub != null && sub.length != null
+          ? sub.map((sub) => TopicSubscription.fromMessage(sub)).toList()
+          : [],
       tags: msg['tags']?.cast<String>(),
       cred: msg['cred'] != null && msg['cred'].length > 0
-          ? msg['cred'].map((dynamic cred) => Credential.fromMessage(cred)).toList().cast<Credential>()
+          ? msg['cred']
+              .map((dynamic cred) => Credential.fromMessage(cred))
+              .toList()
+              .cast<Credential>()
           : [],
-      del: msg['del'] != null ? DeleteTransaction.fromMessage(msg['del']) : null,
+      del:
+          msg['del'] != null ? DeleteTransaction.fromMessage(msg['del']) : null,
     );
   }
 }
@@ -210,8 +226,9 @@ class PresMessage {
       what: msg['what'],
       seq: msg['seq'],
       clear: msg['clear'],
-      delseq:
-          msg['delseq'] != null && msg['delseq'].length != null ? msg['delseq'].map((seq) => DeleteTransactionRange.fromMessage(seq)).toList() : [],
+      // delseq:
+      //     msg['delseq'] != null && msg['delseq'].length != null ? msg['delseq'].map((seq) => DeleteTransactionRange.fromMessage(seq)).toList() : [],
+      delseq: msg['delseq'] != null && msg['delseq'].length != null ? [] : [],
       ua: msg['ua'],
       act: msg['act'],
       tgt: msg['tgt'],

--- a/lib/src/services/configuration.dart
+++ b/lib/src/services/configuration.dart
@@ -15,7 +15,7 @@ class ConfigService {
   ConfigService(bool loggerEnabled) {
     _appSettings = AppSettings(0xFFFFFFF, 503, 1000, 5000);
     deviceToken = null;
-    appVersion = '1.0.0-alpha.2';
+    appVersion = '0.22.10';
     humanLanguage = 'en-US';
     this.loggerEnabled = loggerEnabled;
   }
@@ -29,7 +29,11 @@ class ConfigService {
   }
 
   String get userAgent {
-    return appName + ' (Dart; ' + Platform.operatingSystem + '); tinode-dart/' + appVersion;
+    return appName +
+        ' (Dart; ' +
+        Platform.operatingSystem +
+        '); tinode-dart/' +
+        appVersion;
   }
 
   String get platform {

--- a/lib/src/services/configuration.dart
+++ b/lib/src/services/configuration.dart
@@ -29,11 +29,7 @@ class ConfigService {
   }
 
   String get userAgent {
-    return appName +
-        ' (Dart; ' +
-        Platform.operatingSystem +
-        '); tinode-dart/' +
-        appVersion;
+    return appName + ' ; tinode-dart/' + appVersion;
   }
 
   String get platform {

--- a/lib/src/services/connection.dart
+++ b/lib/src/services/connection.dart
@@ -51,7 +51,8 @@ class ConnectionService {
       _loggerService.warn('Reconnecting...');
     }
     _connecting = true;
-    _ws = await WebSocket.connect(Tools.makeBaseURL(_options)).timeout(Duration(milliseconds: 5000));
+    _ws = await WebSocket.connect(Tools.makeBaseURL(_options))
+        .timeout(Duration(milliseconds: 5000));
     _connecting = false;
     _loggerService.log('Connected.');
     _channel = IOWebSocketChannel(_ws!);
@@ -71,7 +72,6 @@ class ConnectionService {
 
   /// Close current websocket connection
   void disconnect() {
-    _channel = null as IOWebSocketChannel;
     _connecting = false;
     _ws?.close(status.goingAway);
     onDisconnect.add(null);

--- a/lib/src/services/connection.dart
+++ b/lib/src/services/connection.dart
@@ -51,8 +51,10 @@ class ConnectionService {
       _loggerService.warn('Reconnecting...');
     }
     _connecting = true;
+
     _ws = await WebSocket.connect(Tools.makeBaseURL(_options))
-        .timeout(Duration(milliseconds: 5000));
+        .timeout(Duration(seconds: 10));
+    _ws!.pingInterval = Duration(seconds: 5);
     _connecting = false;
     _loggerService.log('Connected.');
     _channel = IOWebSocketChannel(_ws!);

--- a/lib/src/services/connection.dart
+++ b/lib/src/services/connection.dart
@@ -73,8 +73,8 @@ class ConnectionService {
   /// Close current websocket connection
   void disconnect() {
     _connecting = false;
-    _ws?.close(status.goingAway);
-    onDisconnect.add(null);
+    _ws!.close(status.goingAway);
+    onDisconnect.add(false);
   }
 
   /// Send network probe to check if connection is indeed live

--- a/lib/src/services/future-manager.dart
+++ b/lib/src/services/future-manager.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: unnecessary_null_comparison
+
 import 'package:get_it/get_it.dart';
 import 'dart:async';
 
@@ -19,7 +21,8 @@ class FutureManager {
   Future<dynamic> makeFuture(String id) {
     var completer = Completer();
     if (id != null) {
-      _pendingFutures[id] = FutureCallback(completer: completer, ts: DateTime.now());
+      _pendingFutures[id] =
+          FutureCallback(completer: completer, ts: DateTime.now());
     }
     return completer.future;
   }
@@ -32,14 +35,16 @@ class FutureManager {
       if (code >= 200 && code < 400) {
         callbacks.completer?.complete(onOK);
       } else {
-        callbacks.completer?.completeError(Exception((errorText ?? '') + ' (' + code.toString() + ')'));
+        callbacks.completer?.completeError(
+            Exception((errorText ?? '') + ' (' + code.toString() + ')'));
       }
     }
   }
 
   void checkExpiredFutures() {
     var exception = Exception('Timeout (504)');
-    var expires = DateTime.now().subtract(Duration(milliseconds: _configService.appSettings.expireFuturesTimeout));
+    var expires = DateTime.now().subtract(Duration(
+        milliseconds: _configService.appSettings.expireFuturesTimeout));
 
     var markForRemoval = <String>[];
     _pendingFutures.forEach((String key, FutureCallback featureCB) {
@@ -54,10 +59,13 @@ class FutureManager {
   }
 
   void startCheckingExpiredFutures() {
-    if (_expiredFuturesCheckerTimer != null && _expiredFuturesCheckerTimer!.isActive) {
+    if (_expiredFuturesCheckerTimer != null &&
+        _expiredFuturesCheckerTimer!.isActive) {
       return;
     }
-    _expiredFuturesCheckerTimer = Timer.periodic(Duration(milliseconds: _configService.appSettings.expireFuturesPeriod), (_) {
+    _expiredFuturesCheckerTimer = Timer.periodic(
+        Duration(milliseconds: _configService.appSettings.expireFuturesPeriod),
+        (_) {
       checkExpiredFutures();
     });
   }

--- a/lib/src/services/logger.dart
+++ b/lib/src/services/logger.dart
@@ -16,7 +16,9 @@ class LoggerService {
 
   void log(String value) {
     if (_configService.loggerEnabled == true) {
-      print('LOG: ' + value);
+      if (value.contains('out:')) {
+        print('LOG: ' + value);
+      }
     }
   }
 

--- a/lib/src/services/packet-generator.dart
+++ b/lib/src/services/packet-generator.dart
@@ -58,7 +58,6 @@ class PacketGenerator {
       case packet_types.Leave:
         packetData = LeavePacketData(
           topic: topicName,
-          unsub: false,
         );
         break;
 

--- a/lib/src/services/packet-generator.dart
+++ b/lib/src/services/packet-generator.dart
@@ -114,6 +114,7 @@ class PacketGenerator {
         packetData = null as dynamic;
     }
 
-    return Packet(type, packetData, Tools.getNextUniqueId());
+    return Packet(type, packetData,
+        packetData is NotePacketData ? null : Tools.getNextUniqueId());
   }
 }

--- a/lib/src/services/tinode.dart
+++ b/lib/src/services/tinode.dart
@@ -410,6 +410,7 @@ class TinodeService {
     packet.data = data;
     var ctrl = await _send(packet);
     _cacheManager.delete('topic', topicName);
+    _cacheManager.delete('topic', 'me');
     return ctrl;
   }
 

--- a/lib/src/services/tinode.dart
+++ b/lib/src/services/tinode.dart
@@ -339,7 +339,7 @@ class TinodeService {
   }
 
   /// Publish message to topic. The message should be created by `createMessage`
-  Future publishMessage(Message message) {
+  Future publishBaseMessage(Message message) {
     message.resetLocalValues();
     return _send(message.asPubPacket());
   }

--- a/lib/src/services/tinode.dart
+++ b/lib/src/services/tinode.dart
@@ -151,7 +151,9 @@ class TinodeService {
 
     onPresMessage.add(pres);
 
-    Topic? topic = pres.topic != null ? _cacheManager.get('topic', pres.topic ?? '') : null;
+    Topic? topic = pres.topic != null
+        ? _cacheManager.get('topic', pres.topic ?? '')
+        : null;
     if (topic != null) {
       topic.routePres(pres);
     }
@@ -178,8 +180,11 @@ class TinodeService {
     }
     var formattedPkt = pkt.toMap();
     formattedPkt['id'] = pkt.id;
+    // formattedPkt['id'] = 'arisqi-formmac-1726';
     formattedPkt.keys
-        .where((k) => formattedPkt[k] == null || (formattedPkt[k] is Map && formattedPkt[k].isEmpty))
+        .where((k) =>
+            formattedPkt[k] == null ||
+            (formattedPkt[k] is Map && formattedPkt[k].isEmpty))
         .toList()
         .forEach(formattedPkt.remove);
 
@@ -190,7 +195,8 @@ class TinodeService {
     } catch (e) {
       if (pkt.id != null) {
         _loggerService.error(e.toString());
-        _futureManager.execFuture(pkt.id, _configService.appSettings.networkError, null, 'Error');
+        _futureManager.execFuture(
+            pkt.id, _configService.appSettings.networkError, null, 'Error');
       } else {
         rethrow;
       }
@@ -209,7 +215,8 @@ class TinodeService {
   }
 
   /// Create or update an account
-  Future account(String userId, String scheme, String secret, bool login, AccountParams? params) {
+  Future account(String userId, String scheme, String secret, bool login,
+      AccountParams? params) {
     Packet? packet = _packetGenerator.generate(packet_types.Acc, null);
     var data = packet.data as AccPacketData;
     data.user = userId;
@@ -232,7 +239,8 @@ class TinodeService {
   }
 
   /// Authenticate current session
-  Future<CtrlMessage> login(String scheme, String secret, Map<String, dynamic>? cred) async {
+  Future<CtrlMessage> login(
+      String scheme, String secret, Map<String, dynamic>? cred) async {
     var packet = _packetGenerator.generate(packet_types.Login, null);
     var data = packet.data as LoginPacketData;
     data.scheme = scheme;
@@ -247,7 +255,8 @@ class TinodeService {
   }
 
   /// Send a topic subscription request
-  Future subscribe(String? topicName, GetQuery getParams, SetParams? setParams) {
+  Future subscribe(
+      String? topicName, GetQuery getParams, SetParams? setParams) {
     var packet = _packetGenerator.generate(packet_types.Sub, topicName);
     var data = packet.data as SubPacketData;
 
@@ -266,7 +275,8 @@ class TinodeService {
         if (Tools.isNewGroupTopicName(topicName)) {
           // Full set.desc params are used for new topics only
           data.set?.desc = setParams.desc;
-        } else if (Tools.isP2PTopicName(topicName) && setParams.desc?.defacs != null) {
+        } else if (Tools.isP2PTopicName(topicName) &&
+            setParams.desc?.defacs != null) {
           // Use optional default permissions only.
           data.set?.desc = TopicDescription(defacs: setParams.desc?.defacs);
         }
@@ -314,7 +324,8 @@ class TinodeService {
   }
 
   String newGroupTopicName(bool isChan) {
-    return (isChan ? topic_names.TOPIC_NEW_CHAN : topic_names.TOPIC_NEW) + Tools.getNextUniqueId();
+    return (isChan ? topic_names.TOPIC_NEW_CHAN : topic_names.TOPIC_NEW) +
+        Tools.getNextUniqueId();
   }
 
   Topic newTopicWith(String peerUserId) {
@@ -414,7 +425,8 @@ class TinodeService {
 
   /// Delete credential. Always sent on 'me' topic
   Future deleteCredential(String method, String value) {
-    var packet = _packetGenerator.generate(packet_types.Del, topic_names.TOPIC_ME);
+    var packet =
+        _packetGenerator.generate(packet_types.Del, topic_names.TOPIC_ME);
     var data = packet.data as DelPacketData;
     data.what = 'cred';
     data.cred = {'meth': method, 'val': value};

--- a/lib/src/services/tinode.dart
+++ b/lib/src/services/tinode.dart
@@ -445,9 +445,11 @@ class TinodeService {
   }
 
   /// Notify server that a message or messages were read or received. Does NOT return promise
-  Future note(String topicName, String what, int seq) {
-    if (seq <= 0 || seq >= _configService.appSettings.localSeqId) {
-      throw Exception('Invalid message id ' + seq.toString());
+  Future note(String topicName, String what, int? seq) {
+    if (seq != null) {
+      if (seq <= 0 || seq >= _configService.appSettings.localSeqId) {
+        throw Exception('Invalid message id ' + seq.toString());
+      }
     }
 
     var packet = _packetGenerator.generate(packet_types.Note, topicName);

--- a/lib/src/services/tinode.dart
+++ b/lib/src/services/tinode.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: unnecessary_null_comparison
+
 import 'dart:convert';
 
 import 'package:rxdart/rxdart.dart';

--- a/lib/src/services/tinode.dart
+++ b/lib/src/services/tinode.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 
 import 'package:rxdart/rxdart.dart';
 import 'package:get_it/get_it.dart';
+import 'package:tinode/src/models/message-drafty.dart';
 
 import 'package:tinode/src/models/packet-types.dart' as packet_types;
 import 'package:tinode/src/models/topic-names.dart' as topic_names;
@@ -340,8 +341,20 @@ class TinodeService {
     return Message(topicName, data, echo);
   }
 
+  /// Create message draft without sending it to the server
+  MessageDraftyReply createMessageDrafty(
+      String topicName, dynamic head, dynamic data, bool? echo) {
+    echo ??= true;
+    return MessageDraftyReply(topicName, head, data, echo);
+  }
+
   /// Publish message to topic. The message should be created by `createMessage`
-  Future publishBaseMessage(Message message) {
+  Future publishMessage(Message message) {
+    message.resetLocalValues();
+    return _send(message.asPubPacket());
+  }
+
+  Future publishMessageDrafty(MessageDraftyReply message) {
     message.resetLocalValues();
     return _send(message.asPubPacket());
   }

--- a/lib/src/services/tools.dart
+++ b/lib/src/services/tools.dart
@@ -24,7 +24,10 @@ class Tools {
 
   /// Json parser helper to read messages and converting data to native objects
   static dynamic jsonParserHelper(key, value) {
-    if (key == 'ts' && value is String && value.length >= 20 && value.length <= 24) {
+    if (key == 'ts' &&
+        value is String &&
+        value.length >= 20 &&
+        value.length <= 24) {
       var date = DateTime.parse(value);
       return date;
     } else if (key == 'acs' && value is Map) {
@@ -70,13 +73,17 @@ class Tools {
   /// Figure out if the topic name belongs to a new group
   static bool isNewGroupTopicName(String topicName) {
     var prefix = topicName.substring(0, 3);
-    return (topicName is String) && (prefix == topic_names.TOPIC_NEW || prefix == topic_names.TOPIC_NEW_CHAN);
+    return (topicName is String) &&
+        (prefix == topic_names.TOPIC_NEW ||
+            prefix == topic_names.TOPIC_NEW_CHAN);
   }
 
   /// Figure out if the topic name belongs to a new channel
   static bool isChannelTopicName(String topicName) {
     var prefix = topicName.substring(0, 3);
-    return (topicName is String) && (prefix == topic_names.TOPIC_CHAN || prefix == topic_names.TOPIC_NEW_CHAN);
+    return (topicName is String) &&
+        (prefix == topic_names.TOPIC_CHAN ||
+            prefix == topic_names.TOPIC_NEW_CHAN);
   }
 
   /// Create authorized URL

--- a/lib/src/services/tools.dart
+++ b/lib/src/services/tools.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: unnecessary_null_comparison
+
 import 'dart:math';
 
 import 'package:tinode/src/models/topic-names.dart' as topic_names;

--- a/lib/src/topic.dart
+++ b/lib/src/topic.dart
@@ -252,7 +252,7 @@ class Topic {
     message.setStatus(message_status.SENDING);
 
     try {
-      var response = await _tinodeService.publishMessage(message);
+      var response = await _tinodeService.publishBaseMessage(message);
       CtrlMessage? ctrl;
       if (response is CtrlMessage) {
         ctrl = response;

--- a/lib/src/topic.dart
+++ b/lib/src/topic.dart
@@ -1046,6 +1046,7 @@ class Topic {
 
   /// Calculate ranges of missing messages
   void _updateDeletedRanges() {
+    return;
     var ranges = <DataMessage>[];
     DataMessage prev;
 

--- a/lib/src/topic.dart
+++ b/lib/src/topic.dart
@@ -71,7 +71,8 @@ class Topic {
   late List<String> tags;
 
   /// Message cache, sorted by message seq values, from old to new
-  final SortedCache<DataMessage> _messages = SortedCache<DataMessage>((a, b) => (a.seq ?? 0) - (b.seq ?? 0), true);
+  final SortedCache<DataMessage> _messages =
+      SortedCache<DataMessage>((a, b) => (a.seq ?? 0) - (b.seq ?? 0), true);
 
   /// true if the topic is currently live
   bool _subscribed = false;
@@ -128,7 +129,8 @@ class Topic {
   PublishSubject<Topic> onMetaDesc = PublishSubject<Topic>();
 
   /// This event will be triggered when a `meta.sub` message is received
-  PublishSubject<TopicSubscription> onMetaSub = PublishSubject<TopicSubscription>();
+  PublishSubject<TopicSubscription> onMetaSub =
+      PublishSubject<TopicSubscription>();
 
   /// This event will be triggered when a `pres` message is received
   PublishSubject<PresMessage> onPres = PublishSubject<PresMessage>();
@@ -137,7 +139,8 @@ class Topic {
   PublishSubject<InfoMessage> onInfo = PublishSubject<InfoMessage>();
 
   /// This event will be triggered when topic subscriptions are updated
-  PublishSubject<List<TopicSubscription>> onSubsUpdated = PublishSubject<List<TopicSubscription>>();
+  PublishSubject<List<TopicSubscription>> onSubsUpdated =
+      PublishSubject<List<TopicSubscription>>();
 
   /// This event will be triggered when topic tags are updated
   PublishSubject<List<String>> onTagsUpdated = PublishSubject<List<String>>();
@@ -168,15 +171,18 @@ class Topic {
     _subscribed = value;
   }
 
-  Future<CtrlMessage> subscribe(GetQuery getParams, SetParams? setParams) async {
+  Future<CtrlMessage> subscribe(
+      GetQuery getParams, SetParams? setParams) async {
     // If the topic is already subscribed, return resolved promise
     if (isSubscribed) {
-      return Future.error(Exception('topic is already subscribed'));
+      // return Future.error(Exception('topic is already subscribed'));
+      print('Tinode SDK Error: topic is already subscribed');
     }
 
     // Send subscribe message, handle async response.
     // If topic name is explicitly provided, use it. If no name, then it's a new group topic, use "new".
-    var response = await _tinodeService.subscribe(name ?? topic_names.TOPIC_NEW, getParams, setParams);
+    var response = await _tinodeService.subscribe(
+        name ?? topic_names.TOPIC_NEW, getParams, setParams);
     var ctrl = response is CtrlMessage ? response : null;
     var meta = response is MetaMessage ? response : null;
 
@@ -194,7 +200,9 @@ class Topic {
     }
 
     _subscribed = true;
-    acs = (ctrl.params != null && ctrl.params['acs'] != null) ? AccessMode(ctrl.params['acs']) : acs;
+    acs = (ctrl.params != null && ctrl.params['acs'] != null)
+        ? AccessMode(ctrl.params['acs'])
+        : acs;
 
     // Set topic name for new topics and add it to cache.
     if (_new) {
@@ -307,7 +315,8 @@ class Topic {
       query.withEarlierData(limit);
       future = future.then((response) {
         var ctrl = CtrlMessage.fromMessage(response);
-        if (ctrl.params != null && (ctrl.params['count'] == null || ctrl.params['count'] == 0)) {
+        if (ctrl.params != null &&
+            (ctrl.params['count'] == null || ctrl.params['count'] == 0)) {
           _noEarlierMsgs = true;
         }
       });
@@ -371,7 +380,9 @@ class Topic {
   /// Update access mode of the current user or of another topic subscriber
   Future<CtrlMessage> updateMode(String? userId, String update) {
     var user = userId != null && userId != '' ? subscriber(userId) : null;
-    var am = user != null ? user.acs!.updateGiven(update).getGiven() : getAccessMode().updateWant(update).getWant();
+    var am = user != null
+        ? user.acs!.updateGiven(update).getGiven()
+        : getAccessMode().updateWant(update).getWant();
     return setMeta(SetParams(sub: TopicSubscription(user: userId, mode: am)));
   }
 
@@ -385,13 +396,16 @@ class Topic {
     if (private && private.arch == archive) {
       return Future.error(Exception('Cannot publish on inactive topic'));
     }
-    return setMeta(SetParams(desc: TopicDescription(private: {'archive': archive ? true : DEL_CHAR})));
+    return setMeta(SetParams(
+        desc:
+            TopicDescription(private: {'archive': archive ? true : DEL_CHAR})));
   }
 
   /// Delete messages. Hard-deleting messages requires Owner permission
   Future<CtrlMessage> deleteMessages(List<DelRange> ranges, bool hard) async {
     if (!isSubscribed) {
-      return Future.error(Exception('Cannot delete messages in inactive topic'));
+      return Future.error(
+          Exception('Cannot delete messages in inactive topic'));
     }
 
     ranges.sort((r1, r2) {
@@ -496,7 +510,8 @@ class Topic {
   /// Delete subscription. Requires Share permission. Wrapper for Tinode.deleteSubscription
   Future<CtrlMessage> deleteSubscription(String userId) async {
     if (!isSubscribed) {
-      return Future.error(Exception('Cannot delete subscription in inactive topic'));
+      return Future.error(
+          Exception('Cannot delete subscription in inactive topic'));
     }
     // Send {del} message, return promise
     var ctrl = await _tinodeService.deleteSubscription(name ?? '', userId);
@@ -663,7 +678,10 @@ class Topic {
   void flushMessageRange(int fromId, int untilId) {
     // start, end: find insertion points (nearest == true).
     var since = _messages.find(DataMessage(seq: fromId), true);
-    return since >= 0 ? _messages.deleteRange(since, _messages.find(DataMessage(seq: untilId), true)) : [];
+    return since >= 0
+        ? _messages.deleteRange(
+            since, _messages.find(DataMessage(seq: untilId), true))
+        : [];
   }
 
   /// Get type of the topic: me, p2p, grp, fnd...
@@ -732,7 +750,11 @@ class Topic {
 
     // Update locally cached contact with the new message count.
     var me = _tinodeService.getTopic(topic_names.TOPIC_ME) as TopicMe;
-    me.setMsgReadRecv(name ?? '', (data.from == null || _tinodeService.isMe(data.from!)) ? 'read' : 'msg', data.seq!, data.ts);
+    me.setMsgReadRecv(
+        name ?? '',
+        (data.from == null || _tinodeService.isMe(data.from!)) ? 'read' : 'msg',
+        data.seq!,
+        data.ts);
   }
 
   /// Called by `Tinode`
@@ -780,7 +802,10 @@ class Topic {
         if (user != null) {
           user.online = pres.what == 'on';
         } else {
-          _loggerService.warn('Presence update for an unknown user' + (name ?? '') + ' ' + (pres.src ?? ''));
+          _loggerService.warn('Presence update for an unknown user' +
+              (name ?? '') +
+              ' ' +
+              (pres.src ?? ''));
         }
         break;
 
@@ -814,7 +839,10 @@ class Topic {
           // Known user
           user.acs!.updateAll(pres.dacs);
           // Update user's access mode.
-          processMetaSub([TopicSubscription(user: userId, updated: DateTime.now(), acs: user.acs)]);
+          processMetaSub([
+            TopicSubscription(
+                user: userId, updated: DateTime.now(), acs: user.acs)
+          ]);
         }
 
         break;
@@ -984,7 +1012,8 @@ class Topic {
 
   /// Update global user cache and local subscribers cache
   /// Don't call this method for non-subscribers
-  TopicSubscription? _updateCachedUser(String userId, TopicSubscription object) {
+  TopicSubscription? _updateCachedUser(
+      String userId, TopicSubscription object) {
     var cached = _cacheManager.getUser(userId);
 
     if (cached != null) {
@@ -1054,7 +1083,8 @@ class Topic {
       }
 
       // New message is reducing the existing gap
-      if (data.seq == ((prev.hi != null && prev.hi! > 0) ? prev.hi : prev.seq)! + 1) {
+      if (data.seq ==
+          ((prev.hi != null && prev.hi! > 0) ? prev.hi : prev.seq)! + 1) {
         // No new gap. Replace previous with current.
         prev = data;
         return;
@@ -1079,13 +1109,17 @@ class Topic {
     // All messages could be missing or it could be a new topic with no messages.
     var last = _messages.length > 0 ? _messages.getLast() : null;
     var maxSeq = max(seq!, _maxSeq);
-    if ((maxSeq > 0 && last == null) || (last != null && (((last.hi != null && last.hi! > 0) ? last.hi : last.seq)! < maxSeq))) {
+    if ((maxSeq > 0 && last == null) ||
+        (last != null &&
+            (((last.hi != null && last.hi! > 0) ? last.hi : last.seq)! <
+                maxSeq))) {
       if (last != null && (last.hi != null && last.hi! > 0)) {
         // Extend existing gap
         last.hi = maxSeq;
       } else {
         // Create new gap.
-        ranges.add(DataMessage(seq: last != null ? last.seq! + 1 : 1, hi: maxSeq));
+        ranges.add(
+            DataMessage(seq: last != null ? last.seq! + 1 : 1, hi: maxSeq));
       }
     }
 

--- a/lib/src/topic.dart
+++ b/lib/src/topic.dart
@@ -254,7 +254,7 @@ class Topic {
     message.setStatus(message_status.SENDING);
 
     try {
-      var response = await _tinodeService.publishBaseMessage(message);
+      var response = await _tinodeService.publishMessage(message);
       CtrlMessage? ctrl;
       if (response is CtrlMessage) {
         ctrl = response;

--- a/lib/src/topic.dart
+++ b/lib/src/topic.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: null_argument_to_non_null_type
+
 import 'package:rxdart/rxdart.dart';
 import 'package:get_it/get_it.dart';
 

--- a/lib/tinode.dart
+++ b/lib/tinode.dart
@@ -456,7 +456,7 @@ class Tinode {
   }
 
   /// Notify server that a message or messages were read or received. Does NOT return promise
-  void note(String topicName, String what, int seq) {
+  void note(String topicName, String what, int? seq) {
     _tinodeService.note(topicName, what, seq);
   }
 

--- a/lib/tinode.dart
+++ b/lib/tinode.dart
@@ -108,8 +108,14 @@ class Tinode {
 
   /// on raw ctrl
   PublishSubject<String> onRawCtrl = PublishSubject<String>();
+
+  /// on raw pres
   PublishSubject<String> onRawPres = PublishSubject<String>();
+
+  /// on raw info
   PublishSubject<String> onRawInfo = PublishSubject<String>();
+
+  /// on raw meta
   PublishSubject<String> onRawMeta = PublishSubject<String>();
 
   /// Creates an instance of Tinode interface to interact with tinode server using websocket

--- a/lib/tinode.dart
+++ b/lib/tinode.dart
@@ -5,6 +5,7 @@ import 'dart:convert';
 
 import 'package:rxdart/rxdart.dart';
 import 'package:get_it/get_it.dart';
+import 'package:tinode/src/models/message-drafty.dart';
 
 import 'package:tinode/src/models/topic-names.dart' as topic_names;
 import 'package:tinode/src/models/server-configuration.dart';
@@ -408,14 +409,24 @@ class Tinode {
     return _tinodeService.leave(topicName, unsubscribe);
   }
 
-  /// Create message draft without sending it to the server
+  /// Create message draft without sending it to the server (base type = text or json stringify)
   Message createMessage(String topicName, dynamic data, bool echo) {
     return _tinodeService.createMessage(topicName, data, echo);
   }
 
+  /// Create message draft without sending it to the server (drafty type)
+  MessageDraftyReply createMessageDrafty(
+      String topicName, dynamic head, dynamic data, bool echo) {
+    return _tinodeService.createMessageDrafty(topicName, head, data, echo);
+  }
+
   /// Publish message to topic. The message should be created by `createMessage`
-  Future publishMessage(Message message) {
-    return _tinodeService.publishBaseMessage(message);
+  Future publishBaseMessage(Message message) {
+    return _tinodeService.publishMessage(message);
+  }
+
+  Future publishDraftyMessage(MessageDraftyReply message) {
+    return _tinodeService.publishMessageDrafty(message);
   }
 
   /// Request topic metadata

--- a/lib/tinode.dart
+++ b/lib/tinode.dart
@@ -415,7 +415,7 @@ class Tinode {
 
   /// Publish message to topic. The message should be created by `createMessage`
   Future publishMessage(Message message) {
-    return _tinodeService.publishMessage(message);
+    return _tinodeService.publishBaseMessage(message);
   }
 
   /// Request topic metadata

--- a/lib/tinode.dart
+++ b/lib/tinode.dart
@@ -102,7 +102,11 @@ class Tinode {
 
   /// `onRawResponse` event will be triggered when a message is received value will be a json
   PublishSubject<String> onRawResponse = PublishSubject<String>();
+
+  /// on raw data
   PublishSubject<String> onRawData = PublishSubject<String>();
+
+  /// on raw ctrl
   PublishSubject<String> onRawCtrl = PublishSubject<String>();
   PublishSubject<String> onRawPres = PublishSubject<String>();
   PublishSubject<String> onRawInfo = PublishSubject<String>();

--- a/lib/tinode.dart
+++ b/lib/tinode.dart
@@ -100,8 +100,13 @@ class Tinode {
   /// `onMessage` event will be triggered when a message is received
   PublishSubject<ServerMessage> onMessage = PublishSubject<ServerMessage>();
 
-  /// `onRawMessage` event will be triggered when a message is received value will be a json
-  PublishSubject<String> onRawMessage = PublishSubject<String>();
+  /// `onRawResponse` event will be triggered when a message is received value will be a json
+  PublishSubject<String> onRawResponse = PublishSubject<String>();
+  PublishSubject<String> onRawData = PublishSubject<String>();
+  PublishSubject<String> onRawCtrl = PublishSubject<String>();
+  PublishSubject<String> onRawPres = PublishSubject<String>();
+  PublishSubject<String> onRawInfo = PublishSubject<String>();
+  PublishSubject<String> onRawMeta = PublishSubject<String>();
 
   /// Creates an instance of Tinode interface to interact with tinode server using websocket
   ///
@@ -193,8 +198,28 @@ class Tinode {
     }
     _loggerService.log('in: ' + input);
 
-    // Send raw message to listener
-    onRawMessage.add(input);
+    // Send raw response to listener
+    onRawResponse.add(input);
+
+    // TODO BEGINNING CUSTOM LISTENER
+    try {
+      var responseWSTinode = jsonDecode(input);
+      // Send raw response type data to listener
+      if (responseWSTinode['data'] != null) {
+        onRawData.add(input);
+      } else if (responseWSTinode['meta'] != null) {
+        onRawMeta.add(input);
+      } else if (responseWSTinode['ctrl'] != null) {
+        onRawCtrl.add(input);
+      } else if (responseWSTinode['pres'] != null) {
+        onRawPres.add(input);
+      } else if (responseWSTinode['info'] != null) {
+        onRawInfo.add(input);
+      }
+    } catch (e) {
+      print(
+          'ERROR ON DECODE DATA STRING TO JSON FROM TINODE SERVER RESPONSE - ${e.toString()}');
+    }
 
     if (input == '0') {
       onNetworkProbe.add(null);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,9 +8,8 @@ environment:
 
 dependencies:
   rxdart: ^0.27.1
-  web_socket_channel: ^2.4.3
+  web_socket_channel: ^2.1.0
   get_it: ^7.1.3
-  cli_util: ^0.4.1
 
 dev_dependencies:
   pedantic: ^1.11.0


### PR DESCRIPTION
Add Capability, Fixing Functionality, and Redundant Cache Manager

## Overview
- add custom listener to raw response server to client message (meta,data,pres,info,ctrl)
- add capability to send reply drafty chat
- fix : unnecessary cast to prevent error on ws closed.
- fix : cache manager cache value when rejoining topic
- fix : JWRPSD mode on acs params failure builder.


## Changelog

- add custom listener to raw response server to client message (meta,data,pres,info,ctrl)
- add capability to send reply drafty chat
- fix : unnecessary cast to prevent error on ws closed.
- fix : cache manager cache value when rejoining topic
- fix : JWRPSD mode on acs params failure builder.

## Deployment notes
- change your submodule to use latest module version to custom-listener branch or main branch after this PR merged